### PR TITLE
Prevent 'command not found' if rustc is not yet installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ COMPILER = rustc
 RUSTDOC = rustdoc
 
 # Extracts target from rustc.
-TARGET = $(shell rustc --version | awk "/host:/ { print \$$2 }")
+TARGET = $(shell rustc --version 2> /dev/null | awk "/host:/ { print \$$2 }")
 # TARGET = x86_64-unknown-linux-gnu
 # TARGET = x86_64-apple-darwin
 


### PR DESCRIPTION
If rustc is not yet installed, output looks like:

```
$ make nightly-install 
/bin/bash: rustc: command not found
/bin/bash: rustc: command not found
...
Rust install-script stored as '~/rustup.sh'
```

I believe this doesn't have any side effect?
