### PR TITLE
Fixed 'too many arguments' for watch.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,7 @@ watch () {
 CMD=$${1:-make}
 DIR=$${2:-src}
 
-if [ $$CMD = '-h' ]; then
+if [ $${CMD:0:2} = '-h' ]; then
 echo '
 This script will recompile a rust project using `make`
 every time something in the specified directory changes.


### PR DESCRIPTION
This will only look at the first two characters. It precludes any commands starting with `-h` from being used (which should be none).
