### PR TITLE
Fixed "invalid option" on date and stat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -461,13 +461,13 @@ define WATCH_SCRIPT
 watch () {
   if [ -e "$$2" ]; then
     echo "Watching files in $$2.."
-    CTIME=$$(date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s")
+    CTIME=$$(date "+%s")
     while :; do
       sleep 1
       for f in `find $$2 -type f -name "*.rs"`; do
-        eval $$(stat -s $$f)
+        st_mtime=$$(stat -c %Y "$$f")
         if [ $$st_mtime -gt $$CTIME ]; then
-          CTIME=$$(date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s")
+          CTIME=$$(date "+%s")
           echo "~~~ Rebuilding"
           $$1
           if [ ! $$? -eq 0 ]; then


### PR DESCRIPTION
date: invalid option -- 'j'
stat: invalid option -- 's'

I can't find these option on Ubuntu 14.04, nor in any man page (GNU coreutils):
http://unixhelp.ed.ac.uk/CGI/man-cgi?date
http://unixhelp.ed.ac.uk/CGI/man-cgi?stat
