### PR TITLE
Fix target discovery for nightly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ COMPILER = rustc
 RUSTDOC = rustdoc
 
 # Extracts target from rustc.
-TARGET = $(shell rustc --version 2> /dev/null | awk "/host:/ { print \$$2 }")
+TARGET = $(shell rustc --version verbose 2> /dev/null | awk "/host:/ { print \$$2 }")
 # TARGET = x86_64-unknown-linux-gnu
 # TARGET = x86_64-apple-darwin
 


### PR DESCRIPTION
At rust-lang/rust@d6a4c43, `rustc --version` stops printing the target triple, passing to do so only when passed the `verbose` flag.

Sample output:

```
$ rustc --version verbose
rustc 0.11.0-pre (9f8149e185fe55751b8d8675021d2066249abe54 2014-06-25 18:51:21 +0000)
binary: rustc
commit-hash: 9f8149e185fe55751b8d8675021d2066249abe54
commit-date: 2014-06-25 18:51:21 +0000
host: x86_64-unknown-linux-gnu
release: 0.11.0-pre
```
